### PR TITLE
New Pool: wBTC/oBTC

### DIFF
--- a/.github/workflows/obtc.yaml
+++ b/.github/workflows/obtc.yaml
@@ -1,0 +1,55 @@
+name: obtc
+
+on:
+  pull_request:
+    paths:
+      - "tests/**/*.py"
+      - "contracts/pools/obtc/**.vy"
+  push:
+    paths:
+      - "tests/**/*.py"
+      - "contracts/pools/obtc/**.vy"
+
+env:
+  pool: "obtc"
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  NODE_OPTIONS: --max_old_space_size=4096
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        type: [unitary, integration]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Cache Compiler Installations
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.solcx
+            ~/.vvm
+          key: compiler-cache
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v1
+
+      - name: Install Ganache
+        run: npm install
+
+      - name: Setup Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - name: Install Requirements
+        run: |
+          pip install wheel
+          pip install -r requirements.txt
+
+      - name: Run Tests
+        run: brownie test tests/${{ matrix.type }} --network development --pool ${{ env.pool }}

--- a/contracts/pools/obtc/README.md
+++ b/contracts/pools/obtc/README.md
@@ -1,34 +1,20 @@
-# curve-contract/contracts/pools/obtc
+# curve-contract-polygon/contracts/pools/obtc
 
-[Curve oBTC metapool](https://www.curve.fi/obtc), allowing swaps via the Curve [sBTC pool](../sbtc).
+[Curve wBTC/oBTC pool](). This is a no-lending pool.
 
 ## Contracts
 
-* [`DepositOBTC`](DepositOBTC.vy): Depositor contract, used to wrap underlying tokens prior to depositing them into the pool
 * [`StableSwapOBTC`](StableSwapOBTC.vy): Curve stablecoin AMM contract
 
 ## Deployments
 
-[`CurveContractV3`](../../tokens/CurveTokenV3.vy): [0x2fE94ea3d5d4a175184081439753DE15AeF9d614](https://etherscan.io/address/0x2fE94ea3d5d4a175184081439753DE15AeF9d614)
-* [`DepositOBTC`](DepositOBTC.vy): [0xd5BCf53e2C81e1991570f33Fa881c49EEa570C8D](https://etherscan.io/address/0xd5BCf53e2C81e1991570f33Fa881c49EEa570C8D)
-* [`LiquidityGaugeV2`](../../gauges/LiquidityGaugeV2.vy): [0x11137B10C210b579405c21A07489e28F3c040AB1](https://etherscan.io/address/0x11137B10C210b579405c21A07489e28F3c040AB1)
-* [`StableSwapOBTC`](StableSwapOBTC.vy): [0xd81dA8D904b52208541Bade1bD6595D8a251F8dd](https://etherscan.io/address/0xd81dA8D904b52208541Bade1bD6595D8a251F8dd)
+* [`CurveTokenV3`](../../CurveTokenV3.vy): []()
+* [`LiquidityGauge`](../../gauges/LiquidityGauge.vy): []()
+* [`StableSwapRen`](StableSwapOBTC.vy): []()
 
 ## Stablecoins
 
-Curve oBTC metapool utilizes the supports swaps between the following assets:
+Curve oBTC pool supports swaps between the following stablecoins:
 
-## Direct swaps
-
-Direct swaps are possible between oBTC and the Curve sBTC LP token.
-
-* `oBTC`: [0x8064d9Ae6cDf087b1bcd5BDf3531bD5d8C537a68](https://etherscan.io/address/0x8064d9Ae6cDf087b1bcd5BDf3531bD5d8C537a68)
-* `sbtcCRV`: [0x075b1bb99792c9E1041bA13afEf80C91a1e70fB3](https://etherscan.io/address/0x075b1bb99792c9E1041bA13afEf80C91a1e70fB3)
-
-## Base Pool coins
-
-The sBTC LP token may be wrapped or unwrapped to provide swaps between oBTC and the following coins:
-
-* `renBTC`: [0xeb4c2781e4eba804ce9a9803c67d0893436bb27d](https://etherscan.io/address/0xeb4c2781e4eba804ce9a9803c67d0893436bb27d)
-* `wBTC`: [0x2260fac5e5542a773aa44fbcfedf7c193bc2c599](https://etherscan.io/address/0x2260fac5e5542a773aa44fbcfedf7c193bc2c599)
-* `sBTC`: [0xfe18be6b3bd88a2d2a7f928d00292e7a9963cfc6](https://etherscan.io/address/0xfe18be6b3bd88a2d2a7f928d00292e7a9963cfc6)
+* `wBTC`: [0x1BFD67037B42Cf73acF2047067bd4F2C47D9BfD6](https://explorer-mainnet.maticvigil.com/address/0x1BFD67037B42Cf73acF2047067bd4F2C47D9BfD6/transactions)
+* `oBTC`: [0x90fB380DdEbAF872cc1F8d8e8C604Ff2f4697c19](https://explorer-mainnet.maticvigil.com/address/0x90fB380DdEbAF872cc1F8d8e8C604Ff2f4697c19/transactions)

--- a/contracts/pools/obtc/README.md
+++ b/contracts/pools/obtc/README.md
@@ -1,0 +1,34 @@
+# curve-contract/contracts/pools/obtc
+
+[Curve oBTC metapool](https://www.curve.fi/obtc), allowing swaps via the Curve [sBTC pool](../sbtc).
+
+## Contracts
+
+* [`DepositOBTC`](DepositOBTC.vy): Depositor contract, used to wrap underlying tokens prior to depositing them into the pool
+* [`StableSwapOBTC`](StableSwapOBTC.vy): Curve stablecoin AMM contract
+
+## Deployments
+
+[`CurveContractV3`](../../tokens/CurveTokenV3.vy): [0x2fE94ea3d5d4a175184081439753DE15AeF9d614](https://etherscan.io/address/0x2fE94ea3d5d4a175184081439753DE15AeF9d614)
+* [`DepositOBTC`](DepositOBTC.vy): [0xd5BCf53e2C81e1991570f33Fa881c49EEa570C8D](https://etherscan.io/address/0xd5BCf53e2C81e1991570f33Fa881c49EEa570C8D)
+* [`LiquidityGaugeV2`](../../gauges/LiquidityGaugeV2.vy): [0x11137B10C210b579405c21A07489e28F3c040AB1](https://etherscan.io/address/0x11137B10C210b579405c21A07489e28F3c040AB1)
+* [`StableSwapOBTC`](StableSwapOBTC.vy): [0xd81dA8D904b52208541Bade1bD6595D8a251F8dd](https://etherscan.io/address/0xd81dA8D904b52208541Bade1bD6595D8a251F8dd)
+
+## Stablecoins
+
+Curve oBTC metapool utilizes the supports swaps between the following assets:
+
+## Direct swaps
+
+Direct swaps are possible between oBTC and the Curve sBTC LP token.
+
+* `oBTC`: [0x8064d9Ae6cDf087b1bcd5BDf3531bD5d8C537a68](https://etherscan.io/address/0x8064d9Ae6cDf087b1bcd5BDf3531bD5d8C537a68)
+* `sbtcCRV`: [0x075b1bb99792c9E1041bA13afEf80C91a1e70fB3](https://etherscan.io/address/0x075b1bb99792c9E1041bA13afEf80C91a1e70fB3)
+
+## Base Pool coins
+
+The sBTC LP token may be wrapped or unwrapped to provide swaps between oBTC and the following coins:
+
+* `renBTC`: [0xeb4c2781e4eba804ce9a9803c67d0893436bb27d](https://etherscan.io/address/0xeb4c2781e4eba804ce9a9803c67d0893436bb27d)
+* `wBTC`: [0x2260fac5e5542a773aa44fbcfedf7c193bc2c599](https://etherscan.io/address/0x2260fac5e5542a773aa44fbcfedf7c193bc2c599)
+* `sBTC`: [0xfe18be6b3bd88a2d2a7f928d00292e7a9963cfc6](https://etherscan.io/address/0xfe18be6b3bd88a2d2a7f928d00292e7a9963cfc6)

--- a/contracts/pools/obtc/StableSwapOBTC.vy
+++ b/contracts/pools/obtc/StableSwapOBTC.vy
@@ -1,0 +1,889 @@
+# @version 0.2.12
+"""
+@title Curve wbtc/obtc pool for use on Polygon
+@author Curve.Fi
+@license Copyright (c) Curve.Fi, 2021 - all rights reserved
+@notice Pool implementation with no lending
+"""
+
+from vyper.interfaces import ERC20
+
+interface CurveToken:
+    def totalSupply() -> uint256: view
+    def mint(_to: address, _value: uint256) -> bool: nonpayable
+    def burnFrom(_to: address, _value: uint256) -> bool: nonpayable
+
+
+# Events
+event TokenExchange:
+    buyer: indexed(address)
+    sold_id: int128
+    tokens_sold: uint256
+    bought_id: int128
+    tokens_bought: uint256
+
+event AddLiquidity:
+    provider: indexed(address)
+    token_amounts: uint256[N_COINS]
+    fees: uint256[N_COINS]
+    invariant: uint256
+    token_supply: uint256
+
+event RemoveLiquidity:
+    provider: indexed(address)
+    token_amounts: uint256[N_COINS]
+    fees: uint256[N_COINS]
+    token_supply: uint256
+
+event RemoveLiquidityOne:
+    provider: indexed(address)
+    token_amount: uint256
+    coin_amount: uint256
+    token_supply: uint256
+
+event RemoveLiquidityImbalance:
+    provider: indexed(address)
+    token_amounts: uint256[N_COINS]
+    fees: uint256[N_COINS]
+    invariant: uint256
+    token_supply: uint256
+
+event CommitNewAdmin:
+    deadline: indexed(uint256)
+    admin: indexed(address)
+
+event NewAdmin:
+    admin: indexed(address)
+
+event CommitNewFee:
+    deadline: indexed(uint256)
+    fee: uint256
+    admin_fee: uint256
+
+event NewFee:
+    fee: uint256
+    admin_fee: uint256
+
+event RampA:
+    old_A: uint256
+    new_A: uint256
+    initial_time: uint256
+    future_time: uint256
+
+event StopRampA:
+    A: uint256
+    t: uint256
+
+
+# These constants must be set prior to compiling
+N_COINS: constant(int128) = 2
+PRECISION_MUL: constant(uint256[N_COINS]) = [10000000000, 1]
+RATES: constant(uint256[N_COINS]) = [100000000000000000000000000, 1000000000000000000]
+
+# fixed constants
+FEE_DENOMINATOR: constant(uint256) = 10 ** 10
+PRECISION: constant(uint256) = 10 ** 18  # The precision to convert to
+
+MAX_ADMIN_FEE: constant(uint256) = 10 * 10 ** 9
+MAX_FEE: constant(uint256) = 5 * 10 ** 9
+MAX_A: constant(uint256) = 10 ** 6
+MAX_A_CHANGE: constant(uint256) = 10
+
+ADMIN_ACTIONS_DELAY: constant(uint256) = 3 * 86400
+MIN_RAMP_TIME: constant(uint256) = 86400
+
+coins: public(address[N_COINS])
+balances: public(uint256[N_COINS])
+fee: public(uint256)  # fee * 1e10
+admin_fee: public(uint256)  # admin_fee * 1e10
+
+owner: public(address)
+lp_token: public(address)
+
+A_PRECISION: constant(uint256) = 100
+initial_A: public(uint256)
+future_A: public(uint256)
+initial_A_time: public(uint256)
+future_A_time: public(uint256)
+
+admin_actions_deadline: public(uint256)
+transfer_ownership_deadline: public(uint256)
+future_fee: public(uint256)
+future_admin_fee: public(uint256)
+future_owner: public(address)
+
+is_killed: bool
+kill_deadline: uint256
+KILL_DEADLINE_DT: constant(uint256) = 2 * 30 * 86400
+
+
+@external
+def __init__(
+    _owner: address,
+    _coins: address[N_COINS],
+    _pool_token: address,
+    _A: uint256,
+    _fee: uint256,
+    _admin_fee: uint256
+):
+    """
+    @notice Contract constructor
+    @param _owner Contract owner address
+    @param _coins Addresses of ERC20 conracts of coins
+    @param _pool_token Address of the token representing LP share
+    @param _A Amplification coefficient multiplied by n * (n - 1)
+    @param _fee Fee to charge for exchanges
+    @param _admin_fee Admin fee
+    """
+    for i in range(N_COINS):
+        assert _coins[i] != ZERO_ADDRESS
+    self.coins = _coins
+    self.initial_A = _A * A_PRECISION
+    self.future_A = _A * A_PRECISION
+    self.fee = _fee
+    self.admin_fee = _admin_fee
+    self.owner = _owner
+    self.kill_deadline = block.timestamp + KILL_DEADLINE_DT
+    self.lp_token = _pool_token
+
+
+@view
+@internal
+def _A() -> uint256:
+    """
+    Handle ramping A up or down
+    """
+    t1: uint256 = self.future_A_time
+    A1: uint256 = self.future_A
+
+    if block.timestamp < t1:
+        A0: uint256 = self.initial_A
+        t0: uint256 = self.initial_A_time
+        # Expressions in uint256 cannot have negative numbers, thus "if"
+        if A1 > A0:
+            return A0 + (A1 - A0) * (block.timestamp - t0) / (t1 - t0)
+        else:
+            return A0 - (A0 - A1) * (block.timestamp - t0) / (t1 - t0)
+
+    else:  # when t1 == 0 or block.timestamp >= t1
+        return A1
+
+
+@view
+@external
+def A() -> uint256:
+    return self._A() / A_PRECISION
+
+
+@view
+@external
+def A_precise() -> uint256:
+    return self._A()
+
+
+@view
+@internal
+def _xp() -> uint256[N_COINS]:
+    result: uint256[N_COINS] = RATES
+    for i in range(N_COINS):
+        result[i] = result[i] * self.balances[i] / PRECISION
+    return result
+
+
+@pure
+@internal
+def _xp_mem(_balances: uint256[N_COINS]) -> uint256[N_COINS]:
+    result: uint256[N_COINS] = RATES
+    for i in range(N_COINS):
+        result[i] = result[i] * _balances[i] / PRECISION
+    return result
+
+
+@pure
+@internal
+def _get_D(_xp: uint256[N_COINS], _amp: uint256) -> uint256:
+    """
+    D invariant calculation in non-overflowing integer operations
+    iteratively
+
+    A * sum(x_i) * n**n + D = A * D * n**n + D**(n+1) / (n**n * prod(x_i))
+
+    Converging solution:
+    D[j+1] = (A * n**n * sum(x_i) - D[j]**(n+1) / (n**n prod(x_i))) / (A * n**n - 1)
+    """
+    S: uint256 = 0
+    Dprev: uint256 = 0
+
+    for _x in _xp:
+        S += _x
+    if S == 0:
+        return 0
+
+    D: uint256 = S
+    Ann: uint256 = _amp * N_COINS
+    for _i in range(255):
+        D_P: uint256 = D
+        for _x in _xp:
+            D_P = D_P * D / (_x * N_COINS)  # If division by 0, this will be borked: only withdrawal will work. And that is good
+        Dprev = D
+        D = (Ann * S / A_PRECISION + D_P * N_COINS) * D / ((Ann - A_PRECISION) * D / A_PRECISION + (N_COINS + 1) * D_P)
+        # Equality with the precision of 1
+        if D > Dprev:
+            if D - Dprev <= 1:
+                return D
+        else:
+            if Dprev - D <= 1:
+                return D
+    # convergence typically occurs in 4 rounds or less, this should be unreachable!
+    # if it does happen the pool is borked and LPs can withdraw via `remove_liquidity`
+    raise
+
+
+@view
+@internal
+def _get_D_mem(_balances: uint256[N_COINS], _amp: uint256) -> uint256:
+    return self._get_D(self._xp_mem(_balances), _amp)
+
+
+@view
+@external
+def get_virtual_price() -> uint256:
+    """
+    @notice The current virtual price of the pool LP token
+    @dev Useful for calculating profits
+    @return LP token virtual price normalized to 1e18
+    """
+    D: uint256 = self._get_D(self._xp(), self._A())
+    # D is in the units similar to DAI (e.g. converted to precision 1e18)
+    # When balanced, D = n * x_u - total virtual value of the portfolio
+    token_supply: uint256 = ERC20(self.lp_token).totalSupply()
+    return D * PRECISION / token_supply
+
+
+@view
+@external
+def calc_token_amount(_amounts: uint256[N_COINS], _is_deposit: bool) -> uint256:
+    """
+    @notice Calculate addition or reduction in token supply from a deposit or withdrawal
+    @dev This calculation accounts for slippage, but not fees.
+         Needed to prevent front-running, not for precise calculations!
+    @param _amounts Amount of each coin being deposited
+    @param _is_deposit set True for deposits, False for withdrawals
+    @return Expected amount of LP tokens received
+    """
+    amp: uint256 = self._A()
+    balances: uint256[N_COINS] = self.balances
+    D0: uint256 = self._get_D_mem(balances, amp)
+    for i in range(N_COINS):
+        if _is_deposit:
+            balances[i] += _amounts[i]
+        else:
+            balances[i] -= _amounts[i]
+    D1: uint256 = self._get_D_mem(balances, amp)
+    token_amount: uint256 = CurveToken(self.lp_token).totalSupply()
+    diff: uint256 = 0
+    if _is_deposit:
+        diff = D1 - D0
+    else:
+        diff = D0 - D1
+    return diff * token_amount / D0
+
+
+@external
+@nonreentrant('lock')
+def add_liquidity(_amounts: uint256[N_COINS], _min_mint_amount: uint256) -> uint256:
+    """
+    @notice Deposit coins into the pool
+    @param _amounts List of amounts of coins to deposit
+    @param _min_mint_amount Minimum amount of LP tokens to mint from the deposit
+    @return Amount of LP tokens received by depositing
+    """
+    assert not self.is_killed  # dev: is killed
+
+    amp: uint256 = self._A()
+    old_balances: uint256[N_COINS] = self.balances
+
+    # Initial invariant
+    D0: uint256 = self._get_D_mem(old_balances, amp)
+
+    lp_token: address = self.lp_token
+    token_supply: uint256 = CurveToken(lp_token).totalSupply()
+    new_balances: uint256[N_COINS] = old_balances
+    for i in range(N_COINS):
+        if token_supply == 0:
+            assert _amounts[i] > 0  # dev: initial deposit requires all coins
+        # balances store amounts of c-tokens
+        new_balances[i] += _amounts[i]
+
+    # Invariant after change
+    D1: uint256 = self._get_D_mem(new_balances, amp)
+    assert D1 > D0
+
+    # We need to recalculate the invariant accounting for fees
+    # to calculate fair user's share
+    D2: uint256 = D1
+    fees: uint256[N_COINS] = empty(uint256[N_COINS])
+    mint_amount: uint256 = 0
+    if token_supply > 0:
+        # Only account for fees if we are not the first to deposit
+        fee: uint256 = self.fee * N_COINS / (4 * (N_COINS - 1))
+        admin_fee: uint256 = self.admin_fee
+        for i in range(N_COINS):
+            ideal_balance: uint256 = D1 * old_balances[i] / D0
+            difference: uint256 = 0
+            new_balance: uint256 = new_balances[i]
+            if ideal_balance > new_balance:
+                difference = ideal_balance - new_balance
+            else:
+                difference = new_balance - ideal_balance
+            fees[i] = fee * difference / FEE_DENOMINATOR
+            self.balances[i] = new_balance - (fees[i] * admin_fee / FEE_DENOMINATOR)
+            new_balances[i] -= fees[i]
+        D2 = self._get_D_mem(new_balances, amp)
+        mint_amount = token_supply * (D2 - D0) / D0
+    else:
+        self.balances = new_balances
+        mint_amount = D1  # Take the dust if there was any
+    assert mint_amount >= _min_mint_amount, "Slippage screwed you"
+
+    # Take coins from the sender
+    for i in range(N_COINS):
+        if _amounts[i] > 0:
+            # "safeTransferFrom" which works for ERC20s which return bool or not
+            _response: Bytes[32] = raw_call(
+                self.coins[i],
+                concat(
+                    method_id("transferFrom(address,address,uint256)"),
+                    convert(msg.sender, bytes32),
+                    convert(self, bytes32),
+                    convert(_amounts[i], bytes32),
+                ),
+                max_outsize=32,
+            )
+            if len(_response) > 0:
+                assert convert(_response, bool)  # dev: failed transfer
+            # end "safeTransferFrom"
+
+    # Mint pool tokens
+    CurveToken(lp_token).mint(msg.sender, mint_amount)
+
+    log AddLiquidity(msg.sender, _amounts, fees, D1, token_supply + mint_amount)
+
+    return mint_amount
+
+
+@view
+@internal
+def _get_y(i: int128, j: int128, x: uint256, _xp: uint256[N_COINS]) -> uint256:
+    """
+    Calculate x[j] if one makes x[i] = x
+
+    Done by solving quadratic equation iteratively.
+    x_1**2 + x_1 * (sum' - (A*n**n - 1) * D / (A * n**n)) = D ** (n + 1) / (n ** (2 * n) * prod' * A)
+    x_1**2 + b*x_1 = c
+
+    x_1 = (x_1**2 + c) / (2*x_1 + b)
+    """
+    # x in the input is converted to the same price/precision
+
+    assert i != j       # dev: same coin
+    assert j >= 0       # dev: j below zero
+    assert j < N_COINS  # dev: j above N_COINS
+
+    # should be unreachable, but good for safety
+    assert i >= 0
+    assert i < N_COINS
+
+    A: uint256 = self._A()
+    D: uint256 = self._get_D(_xp, A)
+    Ann: uint256 = A * N_COINS
+    c: uint256 = D
+    S: uint256 = 0
+    _x: uint256 = 0
+    y_prev: uint256 = 0
+
+    for _i in range(N_COINS):
+        if _i == i:
+            _x = x
+        elif _i != j:
+            _x = _xp[_i]
+        else:
+            continue
+        S += _x
+        c = c * D / (_x * N_COINS)
+    c = c * D * A_PRECISION / (Ann * N_COINS)
+    b: uint256 = S + D * A_PRECISION / Ann  # - D
+    y: uint256 = D
+    for _i in range(255):
+        y_prev = y
+        y = (y*y + c) / (2 * y + b - D)
+        # Equality with the precision of 1
+        if y > y_prev:
+            if y - y_prev <= 1:
+                return y
+        else:
+            if y_prev - y <= 1:
+                return y
+    raise
+
+
+@view
+@external
+def get_dy(i: int128, j: int128, _dx: uint256) -> uint256:
+    xp: uint256[N_COINS] = self._xp()
+    rates: uint256[N_COINS] = RATES
+
+    x: uint256 = xp[i] + (_dx * rates[i] / PRECISION)
+    y: uint256 = self._get_y(i, j, x, xp)
+    dy: uint256 = xp[j] - y - 1
+    fee: uint256 = self.fee * dy / FEE_DENOMINATOR
+    return (dy - fee) * PRECISION / rates[j]
+
+
+@external
+@nonreentrant('lock')
+def exchange(i: int128, j: int128, _dx: uint256, _min_dy: uint256) -> uint256:
+    """
+    @notice Perform an exchange between two coins
+    @dev Index values can be found via the `coins` public getter method
+    @param i Index value for the coin to send
+    @param j Index valie of the coin to recieve
+    @param _dx Amount of `i` being exchanged
+    @param _min_dy Minimum amount of `j` to receive
+    @return Actual amount of `j` received
+    """
+    assert not self.is_killed  # dev: is killed
+
+    old_balances: uint256[N_COINS] = self.balances
+    xp: uint256[N_COINS] = self._xp_mem(old_balances)
+
+    rates: uint256[N_COINS] = RATES
+    x: uint256 = xp[i] + _dx * rates[i] / PRECISION
+    y: uint256 = self._get_y(i, j, x, xp)
+
+    dy: uint256 = xp[j] - y - 1  # -1 just in case there were some rounding errors
+    dy_fee: uint256 = dy * self.fee / FEE_DENOMINATOR
+
+    # Convert all to real units
+    dy = (dy - dy_fee) * PRECISION / rates[j]
+    assert dy >= _min_dy, "Exchange resulted in fewer coins than expected"
+
+    dy_admin_fee: uint256 = dy_fee * self.admin_fee / FEE_DENOMINATOR
+    dy_admin_fee = dy_admin_fee * PRECISION / rates[j]
+
+    # Change balances exactly in same way as we change actual ERC20 coin amounts
+    self.balances[i] = old_balances[i] + _dx
+    # When rounding errors happen, we undercharge admin fee in favor of LP
+    self.balances[j] = old_balances[j] - dy - dy_admin_fee
+
+    _response: Bytes[32] = raw_call(
+        self.coins[i],
+        concat(
+            method_id("transferFrom(address,address,uint256)"),
+            convert(msg.sender, bytes32),
+            convert(self, bytes32),
+            convert(_dx, bytes32),
+        ),
+        max_outsize=32,
+    )
+    if len(_response) > 0:
+        assert convert(_response, bool)
+
+    _response = raw_call(
+        self.coins[j],
+        concat(
+            method_id("transfer(address,uint256)"),
+            convert(msg.sender, bytes32),
+            convert(dy, bytes32),
+        ),
+        max_outsize=32,
+    )
+    if len(_response) > 0:
+        assert convert(_response, bool)
+
+    log TokenExchange(msg.sender, i, _dx, j, dy)
+
+    return dy
+
+
+@external
+@nonreentrant('lock')
+def remove_liquidity(_amount: uint256, _min_amounts: uint256[N_COINS]) -> uint256[N_COINS]:
+    """
+    @notice Withdraw coins from the pool
+    @dev Withdrawal amounts are based on current deposit ratios
+    @param _amount Quantity of LP tokens to burn in the withdrawal
+    @param _min_amounts Minimum amounts of underlying coins to receive
+    @return List of amounts of coins that were withdrawn
+    """
+    lp_token: address = self.lp_token
+    total_supply: uint256 = CurveToken(lp_token).totalSupply()
+    amounts: uint256[N_COINS] = empty(uint256[N_COINS])
+
+    for i in range(N_COINS):
+        old_balance: uint256 = self.balances[i]
+        value: uint256 = old_balance * _amount / total_supply
+        assert value >= _min_amounts[i], "Withdrawal resulted in fewer coins than expected"
+        self.balances[i] = old_balance - value
+        amounts[i] = value
+        _response: Bytes[32] = raw_call(
+            self.coins[i],
+            concat(
+                method_id("transfer(address,uint256)"),
+                convert(msg.sender, bytes32),
+                convert(value, bytes32),
+            ),
+            max_outsize=32,
+        )
+        if len(_response) > 0:
+            assert convert(_response, bool)
+
+    CurveToken(lp_token).burnFrom(msg.sender, _amount)  # dev: insufficient funds
+
+    log RemoveLiquidity(msg.sender, amounts, empty(uint256[N_COINS]), total_supply - _amount)
+
+    return amounts
+
+
+@external
+@nonreentrant('lock')
+def remove_liquidity_imbalance(_amounts: uint256[N_COINS], _max_burn_amount: uint256) -> uint256:
+    """
+    @notice Withdraw coins from the pool in an imbalanced amount
+    @param _amounts List of amounts of underlying coins to withdraw
+    @param _max_burn_amount Maximum amount of LP token to burn in the withdrawal
+    @return Actual amount of the LP token burned in the withdrawal
+    """
+    assert not self.is_killed  # dev: is killed
+
+    amp: uint256 = self._A()
+    old_balances: uint256[N_COINS] = self.balances
+    D0: uint256 = self._get_D_mem(old_balances, amp)
+    new_balances: uint256[N_COINS] = old_balances
+    for i in range(N_COINS):
+        new_balances[i] -= _amounts[i]
+    D1: uint256 = self._get_D_mem(new_balances, amp)
+
+    fee: uint256 = self.fee * N_COINS / (4 * (N_COINS - 1))
+    admin_fee: uint256 = self.admin_fee
+    fees: uint256[N_COINS] = empty(uint256[N_COINS])
+    for i in range(N_COINS):
+        new_balance: uint256 = new_balances[i]
+        ideal_balance: uint256 = D1 * old_balances[i] / D0
+        difference: uint256 = 0
+        if ideal_balance > new_balance:
+            difference = ideal_balance - new_balance
+        else:
+            difference = new_balance - ideal_balance
+        fees[i] = fee * difference / FEE_DENOMINATOR
+        self.balances[i] = new_balance - (fees[i] * admin_fee / FEE_DENOMINATOR)
+        new_balances[i] = new_balance - fees[i]
+    D2: uint256 = self._get_D_mem(new_balances, amp)
+
+    lp_token: address = self.lp_token
+    token_supply: uint256 = CurveToken(lp_token).totalSupply()
+    token_amount: uint256 = (D0 - D2) * token_supply / D0
+    assert token_amount != 0  # dev: zero tokens burned
+    token_amount += 1  # In case of rounding errors - make it unfavorable for the "attacker"
+    assert token_amount <= _max_burn_amount, "Slippage screwed you"
+
+    CurveToken(lp_token).burnFrom(msg.sender, token_amount)  # dev: insufficient funds
+    for i in range(N_COINS):
+        if _amounts[i] != 0:
+            _response: Bytes[32] = raw_call(
+                self.coins[i],
+                concat(
+                    method_id("transfer(address,uint256)"),
+                    convert(msg.sender, bytes32),
+                    convert(_amounts[i], bytes32),
+                ),
+                max_outsize=32,
+            )
+            if len(_response) > 0:
+                assert convert(_response, bool)
+
+    log RemoveLiquidityImbalance(msg.sender, _amounts, fees, D1, token_supply - token_amount)
+
+    return token_amount
+
+
+@pure
+@internal
+def _get_y_D(A: uint256, i: int128, _xp: uint256[N_COINS], D: uint256) -> uint256:
+    """
+    Calculate x[i] if one reduces D from being calculated for xp to D
+
+    Done by solving quadratic equation iteratively.
+    x_1**2 + x_1 * (sum' - (A*n**n - 1) * D / (A * n**n)) = D ** (n + 1) / (n ** (2 * n) * prod' * A)
+    x_1**2 + b*x_1 = c
+
+    x_1 = (x_1**2 + c) / (2*x_1 + b)
+    """
+    # x in the input is converted to the same price/precision
+
+    assert i >= 0  # dev: i below zero
+    assert i < N_COINS  # dev: i above N_COINS
+
+    Ann: uint256 = A * N_COINS
+    c: uint256 = D
+    S: uint256 = 0
+    _x: uint256 = 0
+    y_prev: uint256 = 0
+
+    for _i in range(N_COINS):
+        if _i != i:
+            _x = _xp[_i]
+        else:
+            continue
+        S += _x
+        c = c * D / (_x * N_COINS)
+    c = c * D * A_PRECISION / (Ann * N_COINS)
+    b: uint256 = S + D * A_PRECISION / Ann
+    y: uint256 = D
+
+    for _i in range(255):
+        y_prev = y
+        y = (y*y + c) / (2 * y + b - D)
+        # Equality with the precision of 1
+        if y > y_prev:
+            if y - y_prev <= 1:
+                return y
+        else:
+            if y_prev - y <= 1:
+                return y
+    raise
+
+
+@view
+@internal
+def _calc_withdraw_one_coin(_token_amount: uint256, i: int128) -> (uint256, uint256, uint256):
+    # First, need to calculate
+    # * Get current D
+    # * Solve Eqn against y_i for D - _token_amount
+    amp: uint256 = self._A()
+    xp: uint256[N_COINS] = self._xp()
+    D0: uint256 = self._get_D(xp, amp)
+
+    total_supply: uint256 = CurveToken(self.lp_token).totalSupply()
+    D1: uint256 = D0 - _token_amount * D0 / total_supply
+    new_y: uint256 = self._get_y_D(amp, i, xp, D1)
+    xp_reduced: uint256[N_COINS] = xp
+    fee: uint256 = self.fee * N_COINS / (4 * (N_COINS - 1))
+    for j in range(N_COINS):
+        dx_expected: uint256 = 0
+        if j == i:
+            dx_expected = xp[j] * D1 / D0 - new_y
+        else:
+            dx_expected = xp[j] - xp[j] * D1 / D0
+        xp_reduced[j] -= fee * dx_expected / FEE_DENOMINATOR
+
+    dy: uint256 = xp_reduced[i] - self._get_y_D(amp, i, xp_reduced, D1)
+    precisions: uint256[N_COINS] = PRECISION_MUL
+    dy = (dy - 1) / precisions[i]  # Withdraw less to account for rounding errors
+    dy_0: uint256 = (xp[i] - new_y) / precisions[i]  # w/o fees
+
+    return dy, dy_0 - dy, total_supply
+
+
+@view
+@external
+def calc_withdraw_one_coin(_token_amount: uint256, i: int128) -> uint256:
+    """
+    @notice Calculate the amount received when withdrawing a single coin
+    @param _token_amount Amount of LP tokens to burn in the withdrawal
+    @param i Index value of the coin to withdraw
+    @return Amount of coin received
+    """
+    return self._calc_withdraw_one_coin(_token_amount, i)[0]
+
+
+@external
+@nonreentrant('lock')
+def remove_liquidity_one_coin(_token_amount: uint256, i: int128, _min_amount: uint256) -> uint256:
+    """
+    @notice Withdraw a single coin from the pool
+    @param _token_amount Amount of LP tokens to burn in the withdrawal
+    @param i Index value of the coin to withdraw
+    @param _min_amount Minimum amount of coin to receive
+    @return Amount of coin received
+    """
+    assert not self.is_killed  # dev: is killed
+
+    dy: uint256 = 0
+    dy_fee: uint256 = 0
+    total_supply: uint256 = 0
+    dy, dy_fee, total_supply = self._calc_withdraw_one_coin(_token_amount, i)
+    assert dy >= _min_amount, "Not enough coins removed"
+
+    self.balances[i] -= (dy + dy_fee * self.admin_fee / FEE_DENOMINATOR)
+    CurveToken(self.lp_token).burnFrom(msg.sender, _token_amount)  # dev: insufficient funds
+
+    _response: Bytes[32] = raw_call(
+        self.coins[i],
+        concat(
+            method_id("transfer(address,uint256)"),
+            convert(msg.sender, bytes32),
+            convert(dy, bytes32),
+        ),
+        max_outsize=32,
+    )
+    if len(_response) > 0:
+        assert convert(_response, bool)
+
+    log RemoveLiquidityOne(msg.sender, _token_amount, dy, total_supply - _token_amount)
+
+    return dy
+
+
+### Admin functions ###
+@external
+def ramp_A(_future_A: uint256, _future_time: uint256):
+    assert msg.sender == self.owner  # dev: only owner
+    assert block.timestamp >= self.initial_A_time + MIN_RAMP_TIME
+    assert _future_time >= block.timestamp + MIN_RAMP_TIME  # dev: insufficient time
+
+    initial_A: uint256 = self._A()
+    future_A_p: uint256 = _future_A * A_PRECISION
+
+    assert _future_A > 0 and _future_A < MAX_A
+    if future_A_p < initial_A:
+        assert future_A_p * MAX_A_CHANGE >= initial_A
+    else:
+        assert future_A_p <= initial_A * MAX_A_CHANGE
+
+    self.initial_A = initial_A
+    self.future_A = future_A_p
+    self.initial_A_time = block.timestamp
+    self.future_A_time = _future_time
+
+    log RampA(initial_A, future_A_p, block.timestamp, _future_time)
+
+
+@external
+def stop_ramp_A():
+    assert msg.sender == self.owner  # dev: only owner
+
+    current_A: uint256 = self._A()
+    self.initial_A = current_A
+    self.future_A = current_A
+    self.initial_A_time = block.timestamp
+    self.future_A_time = block.timestamp
+    # now (block.timestamp < t1) is always False, so we return saved A
+
+    log StopRampA(current_A, block.timestamp)
+
+
+@external
+def commit_new_fee(_new_fee: uint256, _new_admin_fee: uint256):
+    assert msg.sender == self.owner  # dev: only owner
+    assert self.admin_actions_deadline == 0  # dev: active action
+    assert _new_fee <= MAX_FEE  # dev: fee exceeds maximum
+    assert _new_admin_fee <= MAX_ADMIN_FEE  # dev: admin fee exceeds maximum
+
+    deadline: uint256 = block.timestamp + ADMIN_ACTIONS_DELAY
+    self.admin_actions_deadline = deadline
+    self.future_fee = _new_fee
+    self.future_admin_fee = _new_admin_fee
+
+    log CommitNewFee(deadline, _new_fee, _new_admin_fee)
+
+
+@external
+def apply_new_fee():
+    assert msg.sender == self.owner  # dev: only owner
+    assert block.timestamp >= self.admin_actions_deadline  # dev: insufficient time
+    assert self.admin_actions_deadline != 0  # dev: no active action
+
+    self.admin_actions_deadline = 0
+    fee: uint256 = self.future_fee
+    admin_fee: uint256 = self.future_admin_fee
+    self.fee = fee
+    self.admin_fee = admin_fee
+
+    log NewFee(fee, admin_fee)
+
+
+@external
+def revert_new_parameters():
+    assert msg.sender == self.owner  # dev: only owner
+
+    self.admin_actions_deadline = 0
+
+
+@external
+def commit_transfer_ownership(_owner: address):
+    assert msg.sender == self.owner  # dev: only owner
+    assert self.transfer_ownership_deadline == 0  # dev: active transfer
+
+    deadline: uint256 = block.timestamp + ADMIN_ACTIONS_DELAY
+    self.transfer_ownership_deadline = deadline
+    self.future_owner = _owner
+
+    log CommitNewAdmin(deadline, _owner)
+
+
+@external
+def apply_transfer_ownership():
+    assert msg.sender == self.owner  # dev: only owner
+    assert block.timestamp >= self.transfer_ownership_deadline  # dev: insufficient time
+    assert self.transfer_ownership_deadline != 0  # dev: no active transfer
+
+    self.transfer_ownership_deadline = 0
+    owner: address = self.future_owner
+    self.owner = owner
+
+    log NewAdmin(owner)
+
+
+@external
+def revert_transfer_ownership():
+    assert msg.sender == self.owner  # dev: only owner
+
+    self.transfer_ownership_deadline = 0
+
+
+@view
+@external
+def admin_balances(i: uint256) -> uint256:
+    return ERC20(self.coins[i]).balanceOf(self) - self.balances[i]
+
+
+@external
+def withdraw_admin_fees():
+    assert msg.sender == self.owner  # dev: only owner
+
+    for i in range(N_COINS):
+        coin: address = self.coins[i]
+        value: uint256 = ERC20(coin).balanceOf(self) - self.balances[i]
+        if value > 0:
+            _response: Bytes[32] = raw_call(
+                coin,
+                concat(
+                    method_id("transfer(address,uint256)"),
+                    convert(msg.sender, bytes32),
+                    convert(value, bytes32),
+                ),
+                max_outsize=32,
+            )  # dev: failed transfer
+            if len(_response) > 0:
+                assert convert(_response, bool)
+
+
+@external
+def donate_admin_fees():
+    assert msg.sender == self.owner  # dev: only owner
+    for i in range(N_COINS):
+        self.balances[i] = ERC20(self.coins[i]).balanceOf(self)
+
+
+@external
+def kill_me():
+    assert msg.sender == self.owner  # dev: only owner
+    assert self.kill_deadline > block.timestamp  # dev: deadline has passed
+    self.is_killed = True
+
+
+@external
+def unkill_me():
+    assert msg.sender == self.owner  # dev: only owner
+    self.is_killed = False

--- a/contracts/pools/obtc/pooldata.json
+++ b/contracts/pools/obtc/pooldata.json
@@ -1,0 +1,29 @@
+{
+    "lp_contract": "CurveTokenV1",
+    "wrapped_contract": "renERC20",
+    "swap_address": "0x93054188d876f558f4a66B2EF1d97d16eDf0895B",
+    "lp_token_address": "0x49849C98ae39Fff122806C06791Fa73784FB3675",
+    "gauge_addresses": ["0xB1F2cdeC61db658F091671F5f199635aEF202CAC"],
+    "lp_constructor": {
+        "name": "Curve.fi renBTC/wBTC",
+        "symbol": "crvRenWBTC"
+    },
+    "coins": [
+        {
+            "name": "renBTC",
+            "tethered": false,
+            "wrapped_decimals": 8,
+            "underlying_address": "0xeb4c2781e4eba804ce9a9803c67d0893436bb27d",
+            "wrapped_address": "0xeb4c2781e4eba804ce9a9803c67d0893436bb27d"
+        },
+        {
+            "name": "wBTC",
+            "decimals": 8,
+            "tethered": false,
+            "underlying_address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599"
+        }
+    ],
+    "testing": {
+        "initial_amount": 1000
+    }
+}

--- a/contracts/pools/obtc/pooldata.json
+++ b/contracts/pools/obtc/pooldata.json
@@ -1,29 +1,33 @@
 {
-    "lp_contract": "CurveTokenV1",
-    "wrapped_contract": "renERC20",
-    "swap_address": "0x93054188d876f558f4a66B2EF1d97d16eDf0895B",
-    "lp_token_address": "0x49849C98ae39Fff122806C06791Fa73784FB3675",
-    "gauge_addresses": ["0xB1F2cdeC61db658F091671F5f199635aEF202CAC"],
+    "lp_contract": "CurveTokenV3",
+    "swap_address": "",
+    "lp_token_address": "",
+    "gauge_addresses": [
+        ""
+    ],
     "lp_constructor": {
-        "name": "Curve.fi renBTC/wBTC",
-        "symbol": "crvRenWBTC"
+        "name": "Curve.fi wBTC/oBTC",
+        "symbol": "crvwBTCoBTC"
+    },
+    "swap_constructor": {
+        "_A": 200,
+        "_fee": 4000000,
+        "_admin_fee": 5000000000
     },
     "coins": [
-        {
-            "name": "renBTC",
-            "tethered": false,
-            "wrapped_decimals": 8,
-            "underlying_address": "0xeb4c2781e4eba804ce9a9803c67d0893436bb27d",
-            "wrapped_address": "0xeb4c2781e4eba804ce9a9803c67d0893436bb27d"
-        },
         {
             "name": "wBTC",
             "decimals": 8,
             "tethered": false,
-            "underlying_address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599"
+            "underlying_address": "0x1BFD67037B42Cf73acF2047067bd4F2C47D9BfD6",
+            "underlying_interface": "BridgeToken"
+        },
+        {
+            "name": "oBTC",
+            "tethered": false,
+            "decimals": 18,
+            "underlying_address": "0x90fB380DdEbAF872cc1F8d8e8C604Ff2f4697c19",
+            "underlying_interface": "BridgeToken"
         }
-    ],
-    "testing": {
-        "initial_amount": 1000
-    }
+    ]
 }


### PR DESCRIPTION
### Pool Info

* Name: wBTC/oBTC
* Base template: [Base Swap Template](https://github.com/curvefi/curve-contract/blob/master/contracts/pool-templates/base/SwapTemplateBase.vy)

Matic's POS sidechain has great liquidity in wBTC, however other BTC assets are lagging severely. The next BTC asset with the greatest amount of liquidity is oBTC.

### Tokens

#### wBTC

**General Info**
* Deployment address: [0x1BFD67037B42Cf73acF2047067bd4F2C47D9BfD6](https://explorer-mainnet.maticvigil.com/address/0x1BFD67037B42Cf73acF2047067bd4F2C47D9BfD6)
* Link to the token source code: [Matic POS-Portal contracts](https://github.com/maticnetwork/pos-portal/blob/master/contracts/child/ChildToken/UpgradeableChildERC20/UChildERC20.sol)

**Since this is a side chain deployment of wBTC, the contract is not the same as Ethereum mainnet, and instead is a upgradeable contract deployed by the matic team** 

**Behaviours**
1. On a successful transfer this token: returns True
2. On a failed transfer this token: reverts
3. Are there any special approval behaviors? N/A
4. Is there a transfer fee, or the capability to add a transfer fee in the future? N/A

- [x] I have reviewed the documentation and source code for this token, checking for unexpected behaviours that could affect the pool.

#### oBTC

**General Info**
* Deployment address: [0x90fB380DdEbAF872cc1F8d8e8C604Ff2f4697c19](https://explorer-mainnet.maticvigil.com/address/0x90fB380DdEbAF872cc1F8d8e8C604Ff2f4697c19)
* Link to the token source code: [Matic POS-Portal contracts](https://github.com/maticnetwork/pos-portal/blob/master/contracts/child/ChildToken/UpgradeableChildERC20/UChildERC20.sol)

**Since this is a side chain deployment of oBTC, the contract is not the same as Ethereum mainnet, and instead is a upgradeable contract deployed by the matic team** 

**Behaviours**
1. On a successful transfer this token: returns True
2. On a failed transfer this token: reverts
3. Are there any special approval behaviors? N/A
4. Is there a transfer fee, or the capability to add a transfer fee in the future? N/A

- [x] I have reviewed the documentation and source code for this token, checking for unexpected behaviours that could affect the pool.

### Fees

1. Does this pool include tokens that are already handled by the fee burning process? Yes, tokens can be transferred across the bridge similar to the am3pool already deployed on matic
2. Does this pool include tokens that are not currently being burned, but which can be handled by an already deployed burner? N/A
3. Does this pool require deployment of any new burners? N/A

### Pre-review Checklist

- [x] I have included a `pooldata.json` with accurate token addresses
- [x] I have included a `README.md` with accurate token addresses
- [x] I have added a workflow targetting this pool, and confirmed that all tests are passing within the CI
- [x] I have run `brownie test tests/forked --network polygon-mainnet-fork` locally and confirmed that all tests are passing

### Reviewer Pre-deployment Checklist

- [ ] This PR contains a new workflow file, and the entire test suite is passing
- [ ] I have verified the success / failure behaviours for each token in this pool
- [ ] I have run `brownie test tests/forked --network polygon-mainnet-fork` locally and confirmed that all tests are passing
- [ ] I have verified the fee burning process for this pool and any related pull requests
- [ ] This pool makes no significant modifications to the core math OR has been reviewed personally by [@michwill](https://github.com/michwill)

### Post-deployment Checklist

- [ ] I have deployed a [`RewardsOnlyGauge`](https://github.com/curvefi/curve-dao-contracts/blob/master/contracts/gauges/RewardsOnlyGauge.vy) contract for this pool
- [ ] I have deployed any required fee burner contracts
- [ ] I have added pool and gauge deployment addresses to the `pooldata.json` and `README.md` files within this PR
- [ ] I have opened a pull request on [`curve-docs`](https://github.com/curvefi/curve-docs) to add the new deployment addresses to the documentation
- [ ] I have [created a DAO vote]((https://github.com/curvefi/curve-dao-contracts/blob/master/scripts/voting/new_vote.py)) to add the new gauge and enable/configure fee burning